### PR TITLE
New updates on the Tap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-googleplay',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap-googleplay'],
       install_requires=[
-          'singer-python==5.2.3',
+          'singer-python @ git+https://github.com/peliqan-io/singer-python@master',
           'google-api-python-client==1.7.9',
           'google-cloud-storage==1.16.1',
           'pytz'

--- a/tap_googleplay/__init__.py
+++ b/tap_googleplay/__init__.py
@@ -14,6 +14,7 @@ from dateutil.relativedelta import relativedelta
 
 from google.cloud import storage
 
+
 REQUIRED_CONFIG_KEYS = [
     'key_file',
     'start_date',
@@ -26,8 +27,14 @@ LOGGER = singer.get_logger()
 
 BOOKMARK_DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
+class KeyFile(storage.Client):
 
-class Context:
+    @classmethod
+    def from_service_account_json(cls, json_credentials_path, *args, **kwargs):
+        return cls.from_service_account_info(json_credentials_path, *args, **kwargs)
+
+
+class Context():
     config = {}
     state = {}
     catalog = {}
@@ -35,6 +42,7 @@ class Context:
     stream_map = {}
     new_counts = {}
     updated_counts = {}
+
 
     @classmethod
     def get_catalog_entry(cls, stream_name):
@@ -100,7 +108,8 @@ def discover():
                 'package_name',
                 'dimension_name',
                 'dimension_value'
-            ]
+            ],
+            'metadata' : metadata.to_list(metadata.new())
         }
         streams.append(catalog_entry)
 
@@ -248,7 +257,7 @@ def main():
         Context.config = args.config
         Context.state = args.state
 
-        client = storage.Client.from_service_account_json(Context.config['key_file'])
+        client = KeyFile.from_service_account_json(Context.config['key_file'])
         bucket = client.get_bucket(Context.config['bucket_name'])
 
         sync(bucket)


### PR DESCRIPTION
# Description
This PR describes :

1. Update to **setup.py** enabling Peliqan.io Singer fork to be installed.
2. Changes in **__init__.py** :
           1. **Handling flow for no report** : a try-cache block is implemented to handle when no report is found for the specified data and "report_object" appears None
           2. **Report request frequency** : Report is generated on monthly basis, so to avoid day to day report and repetitive record messages, added "relativedelta(months=1)" and when it comes to month/date same as extraction time month/date, it is also handled where delta changes to timedelta(days=1).
           3. **Same month date management** : For same month when delta becomes timedelta(Days=1), handled the printing of record messaged and state messages, and print the state messages only after each run and the last state message.
           4. **Added metadata key** : Manually added the metadata key as it was not getting generated by the tap.
           5. **Handling Key file object** : Initially, key file path is passed as the value of "key_file" value in config file but now only JSON object of the file is required. class Keyfile is added to _init.py_ file which inherits Storage.Client Class in Google Cloud Storage.


## Change Type

✅ New feature (non-breaking change which adds functionality)
⬜ Bug fix (non-breaking change which fixes an issue)
⬜ Refactor
⬜ Breaking change (fix or feature that would cause existing functionality to not work as expected) 
⬜ This change requires a documentation update



