### PR TITLE
🪿[fix] : Handled iterator change based on time between start and report Extract Time

### DIFF
--- a/tap_googleplay/__init__.py
+++ b/tap_googleplay/__init__.py
@@ -156,11 +156,11 @@ def query_report(bucket):
     bookmark = datetime.strptime(get_bookmark(stream_name), "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=pytz.UTC)
 
     extraction_time = singer.utils.now()
-    if bookmark.month == extraction_time.month and bookmark.year == extraction_time.year :
-        delta=timedelta(days=1)
-    else:
+    if (extraction_time - bookmark).days > 31:
         delta=relativedelta(months=1)
-
+    else:
+        delta=timedelta(days=1)
+    
     iterator = bookmark
     singer.write_bookmark(
         Context.state,
@@ -223,7 +223,7 @@ def query_report(bucket):
                     (iterator + delta).strftime(BOOKMARK_DATE_FORMAT)
             )
             iterator += delta
-            if iterator.month == extraction_time.month and iterator.year == extraction_time.year:
+            if (extraction_time - iterator).days < 31:
                 delta = timedelta(days=1)
             prev_iterator_str = iterator_str
 


### PR DESCRIPTION
## Description
This PR details the issue occurred in data sync in pipeline placed for Skindr. 
Due to changes made in commit `022f3e49ef32538959be9c1350ad51b0f95c7e03` which was supposed to handle the iterator's delta parameter failed to steer on one of the edge case. As a result, when bookmark data be equivalent to months last date, it failed to update the delta to `1 day` but made it `1 month` .  This would cause iterator to stop fetching the report until report extraction time is exactly greater than or equal to a month from bookmarked date.

## Issue Causing Code:
```
if bookmark.month == extraction_time.month and bookmark.year == extraction_time.year :
        delta=timedelta(days=1)
    else:
        delta=relativedelta(months=1)
...
...
...
...

if iterator.month == extraction_time.month and iterator.year == extraction_time.year:
       delta = timedelta(days=1)
```

## Changes
- If difference between exctracttion_time and bookmaked time is greater than 31 days, the delta becomes 1 month, otherwise, it is 1 day.

## Testing 
- Testing has been done on the edge case which caused error and few other possible error-prone start dates

## Change Type
:white_large_square: New feature (non-breaking change which adds functionality)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:white_large_square: Refactor
:white_large_square: Breaking change (fix or feature that would cause existing functionality to not work as expected)
:white_large_square: This change requires a documentation update (edited)